### PR TITLE
Remoção da quebra de linha nas variáveis de descrição e categoria

### DIFF
--- a/tarefas.c
+++ b/tarefas.c
@@ -11,10 +11,12 @@ ERROS criar(Tarefa tarefas[], int *pos){
     clearBuffer();
     printf("Entre com a categoria: ");
     fgets(tarefas[*pos].categoria, 100, stdin);
+    tarefas[*pos].categoria[strcspn(tarefas[*pos].categoria, "\n")] = '\0';
 
     printf("Entre com a descricao: ");
     fgets(tarefas[*pos].descricao, 300, stdin);
-
+    tarefas[*pos].descricao[strcspn(tarefas[*pos].descricao, "\n")] = '\0';
+    
     *pos = *pos + 1;
 
     return OK;


### PR DESCRIPTION
Resolvido o erro onde as variáveis de descrição e categoria continham uma quebra de linha junto do texto.